### PR TITLE
WIP: Dependency and edition update, lint fixes and encoding/decoding binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "mnemonic"
 version = "1.0.0"
-authors = ["Matt Brubeck <mbrubeck@limpet.net>"]
+authors = ["Matt Brubeck <mbrubeck@limpet.net>", "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"]
 license = "MIT"
 description = "Encode any data into a sequence of English words"
 repository = "https://github.com/mbrubeck/rust-mnemonic"
 documentation = "https://docs.rs/mnemonic"
 keywords = ["passphrase", "wordlist", "phonetic", "code", "mnemonicode"]
+edition = "2018"
 
 [dependencies]
-byteorder = "1.0"
-lazy_static = "0.2"
+byteorder = "1"
+lazy_static = "1"
 
 [dev-dependencies]
-quickcheck = "0.4"
+quickcheck = "1"

--- a/src/bin/mndecode.rs
+++ b/src/bin/mndecode.rs
@@ -1,0 +1,8 @@
+use std::io::Read;
+
+fn main() -> mnemonic::Result<()> {
+    let mut input = vec![];
+    std::io::stdin().read_to_end(&mut input)?;
+    mnemonic::decode(input, std::io::stdout())?;
+    Ok(())
+}

--- a/src/bin/mnencode.rs
+++ b/src/bin/mnencode.rs
@@ -1,0 +1,8 @@
+use std::io::Read;
+
+fn main() -> mnemonic::Result<()> {
+    let mut input = vec![];
+    std::io::stdin().read_to_end(&mut input)?;
+    mnemonic::encode(input, std::io::stdout())?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,22 +60,18 @@ impl From<io::Error> for Error {
     fn from(other: io::Error) -> Self { Io(other) }
 }
 
-impl ErrorTrait for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Io(ref e) => e.description(),
-            UnrecognizedWord => "Unrecognized word",
-            UnexpectedRemainder => "Unexpected remainder (possible truncated string)",
-            UnexpectedRemainderWord => "Unexpected 24-bit remainder word",
-            DataPastRemainder => "Unexpected data past 24-bit remainder",
-            InvalidEncoding => "Invalid encoding",
-        }
-    }
-}
+impl ErrorTrait for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        match self {
+            Io(ref e) => write!(f, "{}", e.to_string()),
+            UnrecognizedWord => f.write_str("Unrecognized word"),
+            UnexpectedRemainder => f.write_str("Unexpected remainder (possible truncated string)"),
+            UnexpectedRemainderWord => f.write_str("Unexpected 24-bit remainder word"),
+            DataPastRemainder => f.write_str("Unexpected data past 24-bit remainder"),
+            InvalidEncoding => f.write_str("Invalid encoding"),
+        }
     }
 }
 
@@ -86,9 +82,9 @@ const MN_BASE: u32 = 1626;
 const MN_REMAINDER: usize = 7;
 
 /// Default format for encoding
-pub const MN_FDEFAULT: &'static [u8] = b"x-x-x--";
+pub const MN_FDEFAULT: &[u8] = b"x-x-x--";
 
-static MN_WORDS: [&'static [u8]; MN_BASE as usize + MN_REMAINDER] = [
+static MN_WORDS: [&[u8]; MN_BASE as usize + MN_REMAINDER] = [
     b"academy",  b"acrobat",  b"active",   b"actor",    b"adam",     b"admiral",
     b"adrian",   b"africa",   b"agenda",   b"agent",    b"airline",  b"airport",
     b"aladdin",  b"alarm",    b"alaska",   b"albert",   b"albino",   b"album",
@@ -471,11 +467,7 @@ fn mn_encode_word(src: &[u8], n: usize) -> &'static [u8] {
 }
 
 fn is_ascii_alpha(b: u8) -> bool {
-    match b {
-        b'a'...b'z' |
-        b'A'...b'Z' => true,
-        _ => false
-    }
+    matches!(b, b'a'..=b'z' | b'A'..=b'Z')
 }
 
 /// Decode the mnemonic string `src` into bytes, and write the bytes to `dest`.


### PR DESCRIPTION
Hey there, I stumbled over this during my research for paper backups for PGP keys, and while looking at it, I noticed that there's a few deprecated things in here, and crates that have since been stabilized, so I thought I'd just fix those few things and push an update.

Aside of that, I've included two binaries that can be used for encoding and decoding mnemonicode from the CLI. They are slightly different from the ones in the C version (output isn't quite the same, CLI flags aren't supported), so this might be worth fixing before that part can be merged. On the other hand, these examples are incredibly short in comparison to the ones of the C version, so maybe this is a good thing?

They also read the whole input before producing output, which could be optimized away by always taking 4 bytes, and writing out 3 words before then taking in more input, on the other hand, it's probably not worth it, considering this is an encoding meant for human typing/writing, so if the data is too big to be buffered in memory, it's too big to be handled here as well.